### PR TITLE
Add Factions version check

### DIFF
--- a/src/main/java/de/JeterLP/ChatManager/Utils/HookManager.java
+++ b/src/main/java/de/JeterLP/ChatManager/Utils/HookManager.java
@@ -20,6 +20,10 @@ public class HookManager {
 
     public static boolean checkFactions() {
         Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("Factions");
-        return plugin != null && plugin.isEnabled();
+        if (plugin != null) {
+            return plugin.isEnabled() && plugin.getDescription().getVersion().startsWith("2.");
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Hi, I'm maintainer of a fork of the old Factions 1.8.2 and a user got an error because the integration of ChatEx only works with 2.x but gets enabled also with earlier versions. Would you be so kind and merge this? :)

https://github.com/DRE2N/FactionsOne/issues/2