### PR TITLE
Proposed change to ChatLogger.java

### DIFF
--- a/src/main/java/de/thejeterlp/chatex/utils/ChatLogger.java
+++ b/src/main/java/de/thejeterlp/chatex/utils/ChatLogger.java
@@ -57,13 +57,13 @@ public class ChatLogger {
     }
 
     private static String fileName() {
-        DateFormat date = new SimpleDateFormat("dd-MM-yyyy");
+        DateFormat date = new SimpleDateFormat("yyyy-MM-dd");
         Calendar cal = Calendar.getInstance();
         return date.format(cal.getTime()) + ".log";
     }
 
     private static String prefix(boolean day) {
-        DateFormat date = day ? new SimpleDateFormat("[dd-MM-yyyy HH:mm:ss] ") : new SimpleDateFormat("[HH:mm:ss] ");
+        DateFormat date = day ? new SimpleDateFormat("[yyyy-MM-dd HH:mm:ss] ") : new SimpleDateFormat("[HH:mm:ss] ");
         Calendar cal = Calendar.getInstance();
         return date.format(cal.getTime());
     }


### PR DESCRIPTION
Proposing change to chatlogger.java to better conform with ISO8601 regarding the chat log file.
Changes from dd-MM-yyyy to yyyy-MM-dd

Reasoning:
- by conforming to ISO8601, it allows for better sorting files by string or int
- easier [human] reading of file names and interpreting the names in the directory