### PR TITLE
fixes a typo

### DIFF
--- a/src/main/java/de/thejeterlp/chatex/api/ChatExEvent.java
+++ b/src/main/java/de/thejeterlp/chatex/api/ChatExEvent.java
@@ -48,7 +48,7 @@ public final class ChatExEvent extends PlayerEvent {
         return this.format;
     }
 
-    public void setFormat(String Format) {
+    public void setFormat(String format) {
         this.format = format;
     }
 


### PR DESCRIPTION
the function setFormat(String) in the class ChatExEvent had no effect, due to a typo