### PR TITLE
changed updater link

### DIFF
--- a/src/main/java/de/jeter/chatex/utils/UpdateChecker.java
+++ b/src/main/java/de/jeter/chatex/utils/UpdateChecker.java
@@ -44,7 +44,7 @@ public class UpdateChecker {
         this.file = file;
         this.updateType = updateType;
         this.USER_AGENT = plugin.getName() + " UpdateChecker";
-        this.downloadLink = "https://jenkins.jeter.de/job/" + plugin.getName() + "/%build%/artifact/target/" + file.getName();
+        this.downloadLink = "https://jenkins.jeter.de/job/" + plugin.getName() + "/%build%/artifact/target/ChatEx.jar";
 
         thread = new Thread(new UpdaterRunnable());
         thread.start();


### PR DESCRIPTION
Changed the updater download link to include just "ChatEx.jar" instead of file.getName(), since it can produce errors if the file is named something different. Very simple edit but it has been present for quite some time. 

Example of this is:
[23:25:05 WARN]: java.io.IOException: Server returned HTTP response code: 400 for URL: https://jenkins.jeter.de/job/ChatEx/37/artifact/target/ChatEx (4).jar