### PR TITLE
Updater Compares PatchVersions as float

### DIFF
--- a/src/main/java/de/jeter/chatex/utils/UpdateChecker.java
+++ b/src/main/java/de/jeter/chatex/utils/UpdateChecker.java
@@ -134,8 +134,8 @@ public class UpdateChecker {
      */
     private boolean shouldUpdate(String newVersion, String oldVersion) {
         try {
-            int oldV = Integer.valueOf(oldVersion.replaceAll("\\.", ""));
-            int newV = Integer.valueOf(newVersion.replaceAll("\\.", ""));
+            float oldV = Float.valueOf(oldVersion.replaceAll("\\.", "").replace("v", "."));
+            float newV = Float.valueOf(newVersion.replaceAll("\\.", "").replace("v", "."));
             return oldV < newV;
         } catch (NumberFormatException ex) {
             ex.printStackTrace();


### PR DESCRIPTION
[DE]
Der updater Vergleicht patchversion als float und wirft keine exception beim versuch eine version mit patch zu parsen z.B: "2.4.0.v37" => 240.37

[EN]
The updater compares patchversions as float and doesn't throw an exception at the attempt of trying to parse a patched version eg:  "2.4.0.v37" => 240.37