### PR TITLE
Added violation count system

### DIFF
--- a/src/main/java/de/jeter/chatex/ChatListener.java
+++ b/src/main/java/de/jeter/chatex/ChatListener.java
@@ -1,11 +1,8 @@
 package de.jeter.chatex;
 
 import de.jeter.chatex.plugins.PluginManager;
-import de.jeter.chatex.utils.AntiSpamManager;
-import de.jeter.chatex.utils.ChatLogger;
-import de.jeter.chatex.utils.Config;
-import de.jeter.chatex.utils.Locales;
-import de.jeter.chatex.utils.Utils;
+import de.jeter.chatex.utils.*;
+
 import java.util.UnknownFormatConversionException;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -38,7 +35,7 @@ public class ChatListener implements Listener {
         Player player = event.getPlayer();
         String chatMessage = event.getMessage();
 
-        if (Utils.checkForAds(chatMessage, player)) {
+        if (AntiAdManager.checkForAds(chatMessage, player)) {
             event.getPlayer().sendMessage(Locales.MESSAGES_AD.getString(null).replaceAll("%perm", "chatex.bypassads"));
             event.setCancelled(true);
             return;

--- a/src/main/java/de/jeter/chatex/utils/AntiAdManager.java
+++ b/src/main/java/de/jeter/chatex/utils/AntiAdManager.java
@@ -1,0 +1,117 @@
+package de.jeter.chatex.utils;
+
+import de.jeter.chatex.ChatEx;
+import org.bukkit.entity.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AntiAdManager {
+    private static Map<UUID, Double> uuidErrorMap = new HashMap<>();
+    private static Map<UUID, Long> uuidLongMutedMap = new HashMap<>();
+    private static final Pattern ipPattern = Pattern.compile("((?<![0-9])(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[ ]?[.,-:; ][ ]?(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[ ]?[., ][ ]?(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[ ]?[., ][ ]?(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))(?![0-9]))");
+    private static final Pattern webpattern = Pattern.compile("[-a-zA-Z0-9@:%_\\+.~#?&//=]{2,256}\\.[a-z]{2,4}\\b(\\/[-a-zA-Z0-9@:%_\\+~#?&//=]*)?");
+
+    //replace any spaces in the range of ADS_MAX_LENGTH near . or , | removes () to prevent example(.)com
+    private static final String urlCompactorPatternString = "[\\(\\)]|(\\s(?=.{0," + Config.ADS_MAX_LENGTH.getInt() + "}[,\\.]))|((?<=[,\\.].{0,3})\\s*)";
+
+
+    //Ips are clear
+    private static double checkForIPPattern(String message) {
+        message = message.replaceAll(" ", "");
+        Matcher regexMatcher = ipPattern.matcher(message);
+        while (regexMatcher.find()) {
+            if (regexMatcher.group().length() != 0) {
+                String text = regexMatcher.group().trim().replaceAll("http://", "").replaceAll("https://", "").split("/")[0];
+
+                if (text.split("\\.").length > 4) {
+                    String[] domains = text.split("\\.");
+                    String one = domains[domains.length - 1];
+                    String two = domains[domains.length - 2];
+                    String three = domains[domains.length - 3];
+                    String four = domains[domains.length - 4];
+                    text = one + "." + two + "." + three + "." + four;
+                }
+
+                if (ipPattern.matcher(text).find()) {
+                    if (!Config.ADS_BYPASS.getStringList().contains(regexMatcher.group().trim())) {
+                        return 1;
+                    }
+                }
+            }
+        }
+        return 0;
+    }
+
+    private static double checkForWebPattern(String message) {
+        double messageLength = message.length();
+        double error = 0;
+        message = message.replaceAll(",", ".");
+        message = message.replaceAll(urlCompactorPatternString, "");
+        Matcher regexMatcher = webpattern.matcher(message);
+        while (regexMatcher.find()) {
+            if (regexMatcher.group().length() != 0) {
+                String text = regexMatcher.group().trim().replaceAll("http://", "").replaceAll("https://", "").split("/")[0];
+
+                if (text.split("\\.").length > 2) {
+                    String[] domains = text.split("\\.");
+                    String toplevel = domains[domains.length - 1];
+                    String second = domains[domains.length - 2];
+                    text = second + "." + toplevel;
+                }
+                if (webpattern.matcher(text).find()) {
+                    if (!Config.ADS_BYPASS.getStringList().contains(text)) {
+                        error += text.length();
+                    }
+                }
+            }
+        }
+        return error > 0 ? error / messageLength : 0;
+    }
+
+    public static boolean checkForAds(String msg, Player p) {
+        if (p.hasPermission("chatex.bypassads")) {
+            return false;
+        }
+        if (!Config.ADS_ENABLED.getBoolean()) {
+            return false;
+        }
+        if(uuidLongMutedMap.containsKey(p.getUniqueId())){
+            if(uuidLongMutedMap.get(p.getUniqueId())<System.currentTimeMillis()){
+                uuidLongMutedMap.remove(p.getUniqueId());
+            }else{
+                return true;
+            }
+        }
+        if (!uuidErrorMap.containsKey(p.getUniqueId()) || uuidErrorMap.get(p.getUniqueId()) < 0) {
+            uuidErrorMap.put(p.getUniqueId(), 0d);
+        }
+        double error = checkForIPPattern(msg) + checkForWebPattern(msg);
+        uuidErrorMap.put(p.getUniqueId(), uuidErrorMap.get(p.getUniqueId()) + error);
+        boolean canceled = uuidErrorMap.get(p.getUniqueId()) > Config.ADS_THRESHOLD.getDouble();
+        if (canceled) {
+            if (Config.ADS_CLEAR_THRESHOLD.getBoolean()) {
+                uuidErrorMap.put(p.getUniqueId(), 0d);
+                uuidLongMutedMap.put(p.getUniqueId(), System.currentTimeMillis()+(Config.ADS_BLOCK_FOR.getInt()*1000));
+            }
+            for (Player op : ChatEx.getInstance().getServer().getOnlinePlayers()) {
+                if (!op.hasPermission("chatex.notifyad")) {
+                    continue;
+                }
+                HashMap<String, String> map = new HashMap<>();
+                map.put("%player", p.getName());
+                map.put("%message", msg);
+
+                String message = Locales.MESSAGES_AD_NOTIFY.getString(p).replaceAll("%player", p.getName()).replaceAll("%message", msg);
+                op.sendMessage(message);
+            }
+            ChatLogger.writeToAdFile(p, msg);
+        } else {
+            uuidErrorMap.put(p.getUniqueId(), uuidErrorMap.get(p.getUniqueId()) - Config.ADS_REDUCE_THRESHOLD.getDouble());
+        }
+        return canceled;
+    }
+}

--- a/src/main/java/de/jeter/chatex/utils/Config.java
+++ b/src/main/java/de/jeter/chatex/utils/Config.java
@@ -25,6 +25,11 @@ public enum Config {
     LOCALE("Locale", "en-EN", "Which language do you want? (You can choose betwenn de-DE, fr-FR, pt-BR and en-EN by default.)"),
     ADS_ENABLED("Ads.Enabled", true, "Should we check for ads?"),
     ADS_BYPASS("Ads.Bypass", Arrays.asList("127.0.0.1", "my-domain.com"), "A list with allowed ips or domains."),
+    ADS_THRESHOLD("Ads.Threshold.Block", 0.25,"The threshold required to cancel a message, stacks per message  error = error+(error over length) "),
+    ADS_REDUCE_THRESHOLD("Ads.Threshold.ReduceThreshold", 0.1,"How much threshold is removed per message"),
+    ADS_MAX_LENGTH("Ads.Threshold.MaxLinkLength", 10, "What the max detected link length is smaller = less detections, bigger = messages get blocked faster but more false positives"),
+    ADS_CLEAR_THRESHOLD("Ads.Threshold.Clear", true,"Should the threshold be reseted after a message was blocked?(If disabled players cant write after a violation)"),
+    ADS_BLOCK_FOR("Ads.Threshold.BlockFor",30,"If Ads.Threshold.Clear is enabled for how long should a player be muted?"),
     ADS_LOG("Ads.Log", true, "Should the ads be logged in a file?"),
     ANTISPAM_SECONDS("AntiSpam.Seconds", 5, "The delay between player messages to prevent spam"),
     ANTISPAM_ENABLED("AntiSpam.Enable", true, "Should antispam be enabled?"),
@@ -64,7 +69,7 @@ public enum Config {
     public double getDouble() {
         return cfg.getDouble(path);
     }
-    
+
     public int getInt() {
         return cfg.getInt(path);
     }

--- a/src/main/java/de/jeter/chatex/utils/Utils.java
+++ b/src/main/java/de/jeter/chatex/utils/Utils.java
@@ -1,26 +1,21 @@
 package de.jeter.chatex.utils;
 
-import de.jeter.chatex.ChatEx;
 import de.jeter.chatex.plugins.PluginManager;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.bukkit.Location;
-import org.bukkit.entity.Player;
 
 /**
  * @author TheJeterLP
  */
 public class Utils {
-
-    private static final Pattern ipPattern = Pattern.compile("((?<![0-9])(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[ ]?[.,-:; ][ ]?(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[ ]?[., ][ ]?(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[ ]?[., ][ ]?(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))(?![0-9]))");
-    private static final Pattern webpattern = Pattern.compile("[-a-zA-Z0-9@:%_\\+.~#?&//=]{2,256}\\.[a-z]{2,4}\\b(\\/[-a-zA-Z0-9@:%_\\+~#?&//=]*)?");
 
     // Time Display Formats
     private static final DateFormat dateMonths = new SimpleDateFormat("MM");
@@ -186,81 +181,6 @@ public class Utils {
 
         message = replaceColors(message);
         return message;
-    }
-
-    private static boolean checkForIPPattern(String message) {
-        message = message.replaceAll(" ", "");
-        Matcher regexMatcher = ipPattern.matcher(message);
-        while (regexMatcher.find()) {
-            if (regexMatcher.group().length() != 0) {
-                String text = regexMatcher.group().trim().replaceAll("http://", "").replaceAll("https://", "").split("/")[0];
-
-                if (text.split("\\.").length > 4) {
-                    String[] domains = text.split("\\.");
-                    String one = domains[domains.length - 1];
-                    String two = domains[domains.length - 2];
-                    String three = domains[domains.length - 3];
-                    String four = domains[domains.length - 4];
-                    text = one + "." + two + "." + three + "." + four;
-                }
-
-                if (ipPattern.matcher(text).find()) {
-                    if (!Config.ADS_BYPASS.getStringList().contains(regexMatcher.group().trim())) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private static boolean checkForWebPattern(String message) {
-        message = message.replaceAll(" ", "");
-        Matcher regexMatcher = webpattern.matcher(message);
-        while (regexMatcher.find()) {
-            if (regexMatcher.group().length() != 0) {
-                String text = regexMatcher.group().trim().replaceAll("http://", "").replaceAll("https://", "").split("/")[0];
-
-                if (text.split("\\.").length > 2) {
-                    String[] domains = text.split("\\.");
-                    String toplevel = domains[domains.length - 1];
-                    String second = domains[domains.length - 2];
-                    text = second + "." + toplevel;
-                }
-
-                if (webpattern.matcher(text).find()) {
-                    if (!Config.ADS_BYPASS.getStringList().contains(text)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    public static boolean checkForAds(String msg, Player p) {
-        if (p.hasPermission("chatex.bypassads")) {
-            return false;
-        }
-        if (!Config.ADS_ENABLED.getBoolean()) {
-            return false;
-        }
-        boolean found = checkForIPPattern(msg) || checkForWebPattern(msg);
-        if (found) {
-            for (Player op : ChatEx.getInstance().getServer().getOnlinePlayers()) {
-                if (!op.hasPermission("chatex.notifyad")) {
-                    continue;
-                }
-                HashMap<String, String> map = new HashMap<>();
-                map.put("%player", p.getName());
-                map.put("%message", msg);
-
-                String message = Locales.MESSAGES_AD_NOTIFY.getString(p).replaceAll("%player", p.getName()).replaceAll("%message", msg);
-                op.sendMessage(message);
-            }
-            ChatLogger.writeToAdFile(p, msg);
-        }
-        return found;
     }
 
     public static boolean checkForBlocked(String msg) {


### PR DESCRIPTION
+AntiAdManager
Added to Config:
```
Threshold:
    Block: 0.3
    ReduceThreshold: 0.1
    MaxLinkLength: 10
    Clear: true
    BlockFor: 30
```

Players get added an "error" in a add over message length error so long messages have less error even if there is an ad in there so we store the error and everytime someone writes something the error stacks if the error is > Block the players get muted for "BlockFor" seconds.

The MaxLinkLength: 10 means that a link has an error of 10 characters because everything around a "." in a range of 10 characters gets compressed if you increase that the error per message will increase if you decrease that the error per message get decreased. (Still in relation to the message length)

if you write now a long sentence like: "if you have somany friends get some other people on here.don't team with hackerman." you wont get punished.

if you write " join the minehub(.)com community" you get punished because error/message ratio is high
but if you write "Please consider joining the minehub(.)com community" you get only punished if you write it again (for the confidence)
so we have close to no false positives but it takes more messages to block a player who advertises.

I think thats better, because now every Seerver owner can decide better when players get punished.

Fix for that:
![grafik](https://user-images.githubusercontent.com/62426504/82040839-80a19780-96a7-11ea-8910-d55d4881affe.)
![grafik](https://user-images.githubusercontent.com/62426504/82041431-7502a080-96a8-11ea-8a34-37f65cde5710.png)


Ach ja die nachricht ist wen man gemuted ist dann noch die default "Advertising is not allowed" aber ich muss jetzt deutsch machen 😄 

Kannst ja sowas in der art reinhacken:
```
checkads(): return int

if -1 no advertising
else if 0 default 
else if > 0 "You are temporarily blocked for advertising (+"returnValue"+ seconds remaining)"
```