### PR TITLE
Fix implement static getHandlerList for PlayerUsesRangeModeEvent

### DIFF
--- a/src/main/java/de/jeter/chatex/ChatListener.java
+++ b/src/main/java/de/jeter/chatex/ChatListener.java
@@ -18,10 +18,7 @@
  */
 package de.jeter.chatex;
 
-import de.jeter.chatex.api.events.MessageBlockedByAdManagerEvent;
-import de.jeter.chatex.api.events.MessageBlockedBySpamManagerEvent;
-import de.jeter.chatex.api.events.MessageContainsBlockedWordEvent;
-import de.jeter.chatex.api.events.PlayerUsesRangeModeEvent;
+import de.jeter.chatex.api.events.*;
 import de.jeter.chatex.plugins.PluginManager;
 import de.jeter.chatex.utils.*;
 import de.jeter.chatex.utils.adManager.AdManager;
@@ -102,6 +99,14 @@ public class ChatListener implements Listener {
                     chatMessage = chatMessage.replaceFirst(Pattern.quote(Config.RANGEPREFIX.getString()), "");
                     format = PluginManager.getInstance().getGlobalMessageFormat(player);
                     global = true;
+
+                    PlayerUsesGlobalChatEvent playerUsesGlobalChatEvent = new PlayerUsesGlobalChatEvent(player, chatMessage);
+                    Bukkit.getPluginManager().callEvent(playerUsesGlobalChatEvent);
+                    chatMessage = playerUsesGlobalChatEvent.getMessage();
+                    if (playerUsesGlobalChatEvent.isCancelled()) {
+                        return;
+                    }
+
                 } else {
                     player.sendMessage(Locales.COMMAND_RESULT_NO_PERM.getString(player).replaceAll("%perm", "chatex.chat.global"));
                     event.setCancelled(true);
@@ -116,21 +121,23 @@ public class ChatListener implements Listener {
                         return;
                     } else {
                         event.getRecipients().addAll(Utils.getLocalRecipients(player));
+
+                        PlayerUsesRangeModeEvent playerUsesRangeModeEvent = new PlayerUsesRangeModeEvent(player, chatMessage);
+                        Bukkit.getPluginManager().callEvent(playerUsesRangeModeEvent);
+                        chatMessage = playerUsesRangeModeEvent.getMessage();
+                        if (playerUsesRangeModeEvent.isCancelled()) {
+                            return;
+                        }
                     }
                 }
             }
         }
 
         if (global && Config.BUNGEECORD.getBoolean()) {
-            PlayerUsesRangeModeEvent playerUsesRangeModeEvent = new PlayerUsesRangeModeEvent(player, chatMessage);
-            Bukkit.getPluginManager().callEvent(playerUsesRangeModeEvent);
-
-            chatMessage = playerUsesRangeModeEvent.getMessage();
-            if (!playerUsesRangeModeEvent.isCancelled()) {
-                String msgToSend = Utils.replacePlayerPlaceholders(player, format.replaceAll("%message", Matcher.quoteReplacement(chatMessage)));
-                ChannelHandler.getInstance().sendMessage(player, msgToSend);
-            }
+            String msgToSend = Utils.replacePlayerPlaceholders(player, format.replaceAll("%message", Matcher.quoteReplacement(chatMessage)));
+            ChannelHandler.getInstance().sendMessage(player, msgToSend);
         }
+
         format = Utils.replacePlayerPlaceholders(player, format);
         format = Utils.escape(format);
         format = format.replace("%%message", "%2$s");

--- a/src/main/java/de/jeter/chatex/api/events/PlayerUsesGlobalChatEvent.java
+++ b/src/main/java/de/jeter/chatex/api/events/PlayerUsesGlobalChatEvent.java
@@ -1,0 +1,61 @@
+package de.jeter.chatex.api.events;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerUsesGlobalChatEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private String message;
+    private final Player player;
+    private boolean canceled = false;
+
+    public PlayerUsesGlobalChatEvent(Player player, String message){
+        super(true);
+        this.player = player;
+        this.message = message;
+    }
+
+    /**
+     * @return the player which fired this event
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * @return the message which the player would have written.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     *
+     * @param message set the message which the player writes.
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return canceled;
+    }
+
+    @Override
+    public void setCancelled(boolean b) {
+        canceled = b;
+    }
+}

--- a/src/main/java/de/jeter/chatex/api/events/PlayerUsesRangeModeEvent.java
+++ b/src/main/java/de/jeter/chatex/api/events/PlayerUsesRangeModeEvent.java
@@ -63,6 +63,10 @@ public class PlayerUsesRangeModeEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
     @Override
     public boolean isCancelled() {
         return canceled;


### PR DESCRIPTION
Problem from MOSS discord:

> hello, i just got stucked with this exeption when im trying to use api
> ```
> org.bukkit.plugin.IllegalPluginAccessException: Unable to find handler list for event 
> de.jeter.chatex.api.events.PlayerUsesRangeModeEvent.
> Static getHandlerList method required!
> ```
Pancakes#2181 