### PR TITLE
[MPR] Changed to an pipe setup for cleaner code.

### DIFF
--- a/src/main/java/de/jeter/chatex/pipe/AdHandler.java
+++ b/src/main/java/de/jeter/chatex/pipe/AdHandler.java
@@ -1,0 +1,31 @@
+package de.jeter.chatex.pipe;
+
+import de.jeter.chatex.api.events.MessageBlockedByAdManagerEvent;
+import de.jeter.chatex.utils.Locales;
+import de.jeter.chatex.utils.adManager.AdManager;
+import org.bukkit.Bukkit;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class AdHandler implements PipeHandler{
+    private final AdManager adManager;
+
+    public AdHandler(AdManager adManager) {
+        this.adManager = adManager;
+    }
+
+    @Override
+    public boolean handle(AsyncPlayerChatEvent event) {
+        if (adManager.checkForAds(event.getMessage(), event.getPlayer())) {
+            String message = Locales.MESSAGES_AD.getString(null).replaceAll("%perm", "chatex.bypassads");
+            MessageBlockedByAdManagerEvent messageBlockedByAdManagerEvent = new MessageBlockedByAdManagerEvent(event.getPlayer(), event.getMessage(), message);
+            Bukkit.getPluginManager().callEvent(messageBlockedByAdManagerEvent);
+            event.setMessage(messageBlockedByAdManagerEvent.getMessage());
+            event.setCancelled(!messageBlockedByAdManagerEvent.isCancelled());
+            if (!messageBlockedByAdManagerEvent.isCancelled()) {
+                event.getPlayer().sendMessage(messageBlockedByAdManagerEvent.getPluginMessage());
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/jeter/chatex/pipe/BlockedMessageHandler.java
+++ b/src/main/java/de/jeter/chatex/pipe/BlockedMessageHandler.java
@@ -1,0 +1,25 @@
+package de.jeter.chatex.pipe;
+
+import de.jeter.chatex.api.events.MessageContainsBlockedWordEvent;
+import de.jeter.chatex.utils.Locales;
+import de.jeter.chatex.utils.Utils;
+import org.bukkit.Bukkit;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class BlockedMessageHandler implements PipeHandler {
+    @Override
+    public boolean handle(AsyncPlayerChatEvent event) {
+        if (Utils.checkForBlocked(event.getMessage())) {
+            String message = Locales.MESSAGES_BLOCKED.getString(null);
+            MessageContainsBlockedWordEvent messageContainsBlockedWordEvent = new MessageContainsBlockedWordEvent(event.getPlayer(), event.getMessage(), message);
+            Bukkit.getPluginManager().callEvent(messageContainsBlockedWordEvent);
+            event.setCancelled(!messageContainsBlockedWordEvent.isCancelled());
+            event.setMessage(messageContainsBlockedWordEvent.getMessage());
+            if (!messageContainsBlockedWordEvent.isCancelled()) {
+                event.getPlayer().sendMessage(messageContainsBlockedWordEvent.getPluginMessage());
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/jeter/chatex/pipe/BungeeHandler.java
+++ b/src/main/java/de/jeter/chatex/pipe/BungeeHandler.java
@@ -1,0 +1,75 @@
+package de.jeter.chatex.pipe;
+
+import de.jeter.chatex.ChannelHandler;
+import de.jeter.chatex.api.events.PlayerUsesGlobalChatEvent;
+import de.jeter.chatex.api.events.PlayerUsesRangeModeEvent;
+import de.jeter.chatex.plugins.PluginManager;
+import de.jeter.chatex.utils.Config;
+import de.jeter.chatex.utils.Locales;
+import de.jeter.chatex.utils.Utils;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BungeeHandler implements PipeHandler {
+    @Override
+    public boolean handle(AsyncPlayerChatEvent event) {
+        String chatMessage = event.getMessage();
+        Player player = event.getPlayer();
+        String format = event.getFormat();
+        boolean global = false;
+        if (Config.RANGEMODE.getBoolean() || Config.BUNGEECORD.getBoolean()) {
+            if (chatMessage.startsWith(Config.RANGEPREFIX.getString())) {
+                if (player.hasPermission("chatex.chat.global")) {
+                    chatMessage = chatMessage.replaceFirst(Pattern.quote(Config.RANGEPREFIX.getString()), "");
+                    format = PluginManager.getInstance().getGlobalMessageFormat(player);
+                    global = true;
+
+                    PlayerUsesGlobalChatEvent playerUsesGlobalChatEvent = new PlayerUsesGlobalChatEvent(player, chatMessage);
+                    Bukkit.getPluginManager().callEvent(playerUsesGlobalChatEvent);
+                    chatMessage = playerUsesGlobalChatEvent.getMessage();
+                    if (playerUsesGlobalChatEvent.isCancelled()) {
+                        event.setCancelled(true);
+                        return false;
+                    }
+
+                } else {
+                    player.sendMessage(Locales.COMMAND_RESULT_NO_PERM.getString(player).replaceAll("%perm", "chatex.chat.global"));
+                    event.setCancelled(true);
+                    return false;
+                }
+            } else {
+                if (Config.RANGEMODE.getBoolean()) {
+                    event.getRecipients().clear();
+                    if (Utils.getLocalRecipients(player).size() == 1 && Config.SHOW_NO_RECEIVER_MSG.getBoolean()) {
+                        player.sendMessage(Locales.NO_LISTENING_PLAYERS.getString(player));
+                        event.setCancelled(true);
+                        return false;
+                    } else {
+                        event.getRecipients().addAll(Utils.getLocalRecipients(player));
+
+                        PlayerUsesRangeModeEvent playerUsesRangeModeEvent = new PlayerUsesRangeModeEvent(player, chatMessage);
+                        Bukkit.getPluginManager().callEvent(playerUsesRangeModeEvent);
+                        chatMessage = playerUsesRangeModeEvent.getMessage();
+                        if (playerUsesRangeModeEvent.isCancelled()) {
+                            event.setCancelled(true);
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (global && Config.BUNGEECORD.getBoolean()) {
+            String msgToSend = Utils.replacePlayerPlaceholders(player, format.replaceAll("%message", Matcher.quoteReplacement(chatMessage)));
+            ChannelHandler.getInstance().sendMessage(player, msgToSend);
+        }
+
+        event.setFormat(format);
+        event.setMessage(chatMessage);
+        return true;
+    }
+}

--- a/src/main/java/de/jeter/chatex/pipe/ChatPermissionHandler.java
+++ b/src/main/java/de/jeter/chatex/pipe/ChatPermissionHandler.java
@@ -1,0 +1,17 @@
+package de.jeter.chatex.pipe;
+
+import de.jeter.chatex.utils.Locales;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class ChatPermissionHandler implements PipeHandler{
+    @Override
+    public boolean handle(AsyncPlayerChatEvent event) {
+        if (!event.getPlayer().hasPermission("chatex.allowchat")) {
+            String msg = Locales.COMMAND_RESULT_NO_PERM.getString(event.getPlayer()).replaceAll("%perm", "chatex.allowchat");
+            event.getPlayer().sendMessage(msg);
+            event.setCancelled(true);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/de/jeter/chatex/pipe/ChatPipe.java
+++ b/src/main/java/de/jeter/chatex/pipe/ChatPipe.java
@@ -1,0 +1,34 @@
+package de.jeter.chatex.pipe;
+
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChatPipe {
+    private final List<PipeHandler> handlerList = new ArrayList<>();
+
+    public ChatPipe() {
+    }
+
+    /**
+     * Add a {@link PipeHandler} to the end of this pipe
+     * @param pipeHandler the handler to add to this pipe.
+     */
+    public void addLast(PipeHandler pipeHandler) {
+        handlerList.add(pipeHandler);
+    }
+
+    /**
+     * Fires the pipe.
+     * @param asyncPlayerChatEvent the event which to use when fired.
+     */
+    public void handle(AsyncPlayerChatEvent asyncPlayerChatEvent) {
+        for (PipeHandler pipeHandler : handlerList) {
+            System.out.println(pipeHandler.getClass().toString());
+            if(!pipeHandler.handle(asyncPlayerChatEvent)) {
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/de/jeter/chatex/pipe/NonCheckingAsyncChatEvent.java
+++ b/src/main/java/de/jeter/chatex/pipe/NonCheckingAsyncChatEvent.java
@@ -1,0 +1,26 @@
+package de.jeter.chatex.pipe;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+import java.util.Set;
+
+public class NonCheckingAsyncChatEvent extends AsyncPlayerChatEvent {
+    private String uncheckedFormat;
+
+    public NonCheckingAsyncChatEvent(boolean async, Player who, String message, Set<Player> players, String format) {
+        super(async, who, message, players);
+        uncheckedFormat = format;
+    }
+
+
+    @Override
+    public void setFormat(String uncheckedFormat) {
+        this.uncheckedFormat = uncheckedFormat;
+    }
+
+    @Override
+    public String getFormat() {
+        return uncheckedFormat;
+    }
+}

--- a/src/main/java/de/jeter/chatex/pipe/PipeHandler.java
+++ b/src/main/java/de/jeter/chatex/pipe/PipeHandler.java
@@ -1,0 +1,13 @@
+package de.jeter.chatex.pipe;
+
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public interface PipeHandler {
+
+    /**
+     * Is called when the {@link ChatPipe} reaches this handler.
+     * @param asyncPlayerChatEvent the ChatEvent which started the pipe
+     * @return Continue the Pipe
+     */
+    boolean handle(AsyncPlayerChatEvent asyncPlayerChatEvent);
+}

--- a/src/main/java/de/jeter/chatex/pipe/SpamManagerHandler.java
+++ b/src/main/java/de/jeter/chatex/pipe/SpamManagerHandler.java
@@ -1,0 +1,27 @@
+package de.jeter.chatex.pipe;
+
+import de.jeter.chatex.api.events.MessageBlockedBySpamManagerEvent;
+import de.jeter.chatex.utils.AntiSpamManager;
+import de.jeter.chatex.utils.Locales;
+import org.bukkit.Bukkit;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class SpamManagerHandler implements PipeHandler {
+    @Override
+    public boolean handle(AsyncPlayerChatEvent event) {
+        if (!AntiSpamManager.getInstance().isAllowed(event.getPlayer())) {
+            long remainingTime = AntiSpamManager.getInstance().getRemainingSeconds(event.getPlayer());
+            String message = Locales.ANTI_SPAM_DENIED.getString(event.getPlayer()).replaceAll("%time%", remainingTime + "");
+            MessageBlockedBySpamManagerEvent messageBlockedBySpamManagerEvent = new MessageBlockedBySpamManagerEvent(event.getPlayer(), event.getMessage(), message, remainingTime);
+            Bukkit.getPluginManager().callEvent(messageBlockedBySpamManagerEvent);
+            event.setCancelled(!messageBlockedBySpamManagerEvent.isCancelled());
+            if (!messageBlockedBySpamManagerEvent.isCancelled()) {
+                event.getPlayer().sendMessage(messageBlockedBySpamManagerEvent.getPluginMessage());
+                return false;
+            }
+            event.setMessage(messageBlockedBySpamManagerEvent.getMessage());
+        }
+        AntiSpamManager.getInstance().put(event.getPlayer());
+        return true;
+    }
+}


### PR DESCRIPTION
# [OPT] ChatEx handler setup
### Goal
This PR adds a pipe setup to ChatEx.
It aims to clean the ever since growing ChatListener.
Instead of just appending the code always to the ChatListener you now can append your handlers to the ChatPipe.

### PipeSetup
The Chat pipe setup:
1) ChatPipe#addLast adds a PipeHandler instance at the end of a list of PipeHandlers
2) ChatPipe#handle(AsyncPlayerChatEvent) loops through them, each handler is able to stop the pipe by returning `false`

### A few more details
ChatEx pases a `NonCheckingPlayerChatEvent` which extends/is the normal `AsyncPlayerChatEvent` but doesn't checks the format so handlers can use event#setFormat even if this format isn't finaliezed yet. (Harder to debug but 100% worth it) 😉 


