### PR TITLE
Added AFK placeholder + Translations in es-ES.yml.

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -66,6 +66,10 @@
       <id>CodeMC</id>
       <url>https://repo.codemc.org/repository/maven-public</url>
     </repository>
+	<repository>
+      <id>essentials-repo</id>
+      <url>https://repo.essentialsx.net/releases/</url>
+    </repository>
   </repositories>
   <dependencies>
     <dependency>
@@ -119,6 +123,12 @@
           <groupId>org.jetbrains</groupId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.ess3</groupId>
+      <artifactId>EssentialsX</artifactId>
+      <version>2.17.2</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
             <id>CodeMC</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
+        <repository>
+            <id>essentials-repo</id>
+            <url>https://repo.essentialsx.net/releases/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -98,6 +102,12 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>1.8</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.ess3</groupId>
+            <artifactId>EssentialsX</artifactId>
+            <version>2.17.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/de/jeter/chatex/ChatEx.java
+++ b/src/main/java/de/jeter/chatex/ChatEx.java
@@ -53,14 +53,14 @@ public class ChatEx extends JavaPlugin {
             getLogger().info("Thanks for using bstats, it was enabled!");
         }
 
-        getLogger().info("is now enabled!");
+        getLogger().info("Is now enabled!");
     }
 
     @Override
     public void onDisable() {
         ChatLogger.close();
         getServer().getScheduler().cancelTasks(this);
-        getLogger().info("is now disabled!");
+        getLogger().info("Is now disabled!");
     }
 
     public static ChatEx getInstance() {

--- a/src/main/java/de/jeter/chatex/EssentialsAFKListener.java
+++ b/src/main/java/de/jeter/chatex/EssentialsAFKListener.java
@@ -1,0 +1,22 @@
+package de.jeter.chatex;
+
+import de.jeter.chatex.utils.Config;
+import de.jeter.chatex.utils.Utils;
+import net.ess3.api.events.AfkStatusChangeEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class EssentialsAFKListener implements Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    public void onAFKChangeEvent(AfkStatusChangeEvent event) {
+        Player player = event.getAffected().getBase();
+        if (event.getValue()) {
+            String format = Config.TABLIST_FORMAT.getString().replace("%afk", Config.AFK_FORMAT.getString());
+            player.setPlayerListName(Utils.replacePlayerPlaceholders(player, format));
+            return;
+        }
+        player.setPlayerListName(Utils.replacePlayerPlaceholders(player, Config.TABLIST_FORMAT.getString()));
+    }
+}

--- a/src/main/java/de/jeter/chatex/plugins/PluginManager.java
+++ b/src/main/java/de/jeter/chatex/plugins/PluginManager.java
@@ -16,6 +16,8 @@
 package de.jeter.chatex.plugins;
 
 import de.jeter.chatex.ChatEx;
+import de.jeter.chatex.EssentialsAFKListener;
+import de.jeter.chatex.utils.Config;
 import de.jeter.chatex.utils.HookManager;
 import de.jeter.chatex.utils.Utils;
 import org.bukkit.entity.Player;
@@ -40,6 +42,15 @@ public class PluginManager implements PermissionsPlugin {
 
         if (HookManager.checkPlaceholderAPI()) {
             ChatEx.getInstance().getLogger().info("Hooked into PlaceholderAPI");
+        }
+
+        if (Config.AFK_PLACEHOLDER.getBoolean()) {
+            if (HookManager.checkEssentials()) {
+                ChatEx.getInstance().getLogger().info("Hooked into Essentials");
+                ChatEx.getInstance().getServer().getPluginManager().registerEvents(new EssentialsAFKListener(), ChatEx.getInstance());
+            } else {
+                ChatEx.getInstance().getLogger().info("Error while enabling AFK placeholder, essentials not found!");
+            }
         }
     }
 

--- a/src/main/java/de/jeter/chatex/utils/Config.java
+++ b/src/main/java/de/jeter/chatex/utils/Config.java
@@ -63,7 +63,9 @@ public enum Config {
     CHANGE_TABLIST_NAME("Tablist.Change", true, "Do you want to have the prefixes and suffixes in the tablist?"),
     TABLIST_FORMAT("Tablist.format", "%prefix%player%suffix", "The format of the tablist name"),
     CHANGE_JOIN_AND_QUIT("Messages.JoinAndQuit.Enabled", false, "Do you want to change the join and the quit messages?"),
-    RGB_COLORS("colors", null, "Requires 1.16+, Colors you want to use.");
+    RGB_COLORS("colors", null, "Requires 1.16+, Colors you want to use."),
+    AFK_PLACEHOLDER("AfkPlaceholder.Enabled", false, "Enable the %afk placeholder. You can use it to display AFK players on tablist. (Requires Essentials)."),
+    AFK_FORMAT("AfkPlaceholder.format", "&r[&7AFK&r] ", "The format of the afk placeholder.");
 
     private final Object value;
     private final String path;

--- a/src/main/java/de/jeter/chatex/utils/HookManager.java
+++ b/src/main/java/de/jeter/chatex/utils/HookManager.java
@@ -33,4 +33,9 @@ public class HookManager {
         return plugin != null && plugin.isEnabled();
     }
 
+    public static boolean checkEssentials() {
+        Plugin plugin = Bukkit.getServer().getPluginManager().getPlugin("Essentials");
+        return plugin != null && plugin.isEnabled();
+    }
+
 }

--- a/src/main/java/de/jeter/chatex/utils/Utils.java
+++ b/src/main/java/de/jeter/chatex/utils/Utils.java
@@ -19,6 +19,7 @@
 package de.jeter.chatex.utils;
 
 import de.jeter.chatex.ChatEx;
+import de.jeter.chatex.EssentialsAFKListener;
 import de.jeter.chatex.plugins.PluginManager;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.ChatColor;
@@ -62,6 +63,10 @@ public class Utils {
 
         if (HookManager.checkPlaceholderAPI()) {
             result = PlaceholderAPI.setPlaceholders(player, result);
+        }
+
+        if (HookManager.checkEssentials() && Config.AFK_PLACEHOLDER.getBoolean()) {
+            result = result.replace("%afk", "");
         }
 
         result = result.replace("%displayname", player.getDisplayName());

--- a/src/main/resources/locales/es-ES.yml
+++ b/src/main/resources/locales/es-ES.yml
@@ -1,8 +1,8 @@
 Commands:
   Reload:
-    Description: Reloads the plugin and its configuration.
+    Description: Recarga el plugin y su configuración.
   Clear:
-    Description: Clears the chat.
+    Description: Borra el chat.
     Console: CONSOLE
     Unknown: UNKNOWN
 Messages:
@@ -15,8 +15,8 @@ Messages:
     AdDetected: '&4[ERROR] &7La publicidad no está permitida! &c(%perm)'
     BlockedWord: '&4[ERROR] &7Trataste de usar una palabra que no está permitida!'
     AdNotify: "&c%player intentó hacer publicidad. Su mensaje fue: \n&a %message"
-    NoOneListens: '&cNo players are near you to hear you talking! Use the ranged mode
-      to chat.'
+    NoOneListens: '&cNo hay jugadores lo suficientemente cerca de ti como para verte
+      hablar. Usa el modo a distancia para charlar.'
   CommandResult:
     NoPermission: '&4[ERROR] &7No tienes permiso para hacer esto! &c(%perm)'
     WrongUsage: '&c[ERROR] &7Sintaxis incorrecta, por favor, usa &6%cmd help&7! para
@@ -29,4 +29,4 @@ Messages:
     Kick: '%prefix%displayname%suffix &efue expulsado del juego!'
     Quit: '%prefix%displayname%suffix &ese fue del juego!'
   UpdateFound: '&a[ChatEx]&7 Una nueva actualización fue encontrada en SpigotMC. Versión
-    actual: %oldversion New version: %newversion'
+    actual: %oldversion Nueva versión: %newversion'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: de.jeter.chatex.ChatEx
 version: ${project.version}
 authors: [Jeter, Wizard_x]
 description: Chat management plugin
-softdepend: [PermissionsEx, Vault, PlaceholderAPI]
+softdepend: [PermissionsEx, Vault, PlaceholderAPI, Essentials]
 
 commands:
     chatex:


### PR DESCRIPTION
This adds a placeholder called "%afk" that can be used to show the players that are AFK in the tablist. I have put an option to disable this placeholder (and the integration with Essentials, which is needed for this). By default it is disabled.

To activate it, just set in the config "enable" to "true" in "AfkPlaceholder". Once this is done, you can use the variable in the tablist by adding it in format (Example: %afk%prefix%displayname%suffix).

It is better that you try it by yourself.
You can change the text that appears.

Example image:
![image](https://user-images.githubusercontent.com/38667545/120937896-6e5e2580-c710-11eb-904f-6bc7bfc324f0.png)

When the player is no longer AFK, the AFK tag disappears from the tablist.

Also, I'm Spanish, so I've translated some things in the es-ES.yml file.
**Build available here**: https://unserversinley.net/misc/jars/ChatEx_AFK_Placeholder.jar


Regards, cascaseno.

Developed for use at Un Server Sin Ley.
unserversinley.net (1.16.3)