### PR TITLE
Add purpur afk support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
             <id>essentials-repo</id>
             <url>https://repo.essentialsx.net/releases/</url>
         </repository>
+        <repository>
+            <id>purpur</id>
+            <url>https://repo.purpurmc.org/snapshots</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -114,6 +118,12 @@
             <groupId>net.ess3</groupId>
             <artifactId>EssentialsX</artifactId>
             <version>2.18.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.purpurmc.purpur</groupId>
+            <artifactId>purpur-api</artifactId>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.purpurmc.purpur</groupId>
             <artifactId>purpur-api</artifactId>
-            <version>1.19-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/de/jeter/chatex/PurpurAFKListener.java
+++ b/src/main/java/de/jeter/chatex/PurpurAFKListener.java
@@ -1,0 +1,22 @@
+package de.jeter.chatex;
+
+import de.jeter.chatex.utils.Config;
+import de.jeter.chatex.utils.Utils;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.purpurmc.purpur.event.PlayerAFKEvent;
+
+public class PurpurAFKListener implements Listener {
+
+    @EventHandler(ignoreCancelled = true)
+    public void onAFKChangeEvent(PlayerAFKEvent event) {
+        Player player = event.getPlayer();
+        if (event.isGoingAfk()) {
+            String format = Config.TABLIST_FORMAT.getString().replace("%afk", Config.AFK_FORMAT.getString());
+            player.setPlayerListName(Utils.replacePlayerPlaceholders(player, format));
+            return;
+        }
+        player.setPlayerListName(Utils.replacePlayerPlaceholders(player, Config.TABLIST_FORMAT.getString()));
+    }
+}

--- a/src/main/java/de/jeter/chatex/plugins/PluginManager.java
+++ b/src/main/java/de/jeter/chatex/plugins/PluginManager.java
@@ -17,6 +17,7 @@ package de.jeter.chatex.plugins;
 
 import de.jeter.chatex.ChatEx;
 import de.jeter.chatex.EssentialsAFKListener;
+import de.jeter.chatex.PurpurAFKListener;
 import de.jeter.chatex.utils.Config;
 import de.jeter.chatex.utils.HookManager;
 import de.jeter.chatex.utils.Utils;
@@ -48,8 +49,11 @@ public class PluginManager implements PermissionsPlugin {
             if (HookManager.checkEssentials()) {
                 ChatEx.getInstance().getLogger().info("Hooked into Essentials");
                 ChatEx.getInstance().getServer().getPluginManager().registerEvents(new EssentialsAFKListener(), ChatEx.getInstance());
+            } else if (HookManager.checkPurpur()) {
+                ChatEx.getInstance().getLogger().info("Hooked into Purpur");
+                ChatEx.getInstance().getServer().getPluginManager().registerEvents(new PurpurAFKListener(), ChatEx.getInstance());
             } else {
-                ChatEx.getInstance().getLogger().info("Error while enabling AFK placeholder, essentials not found!");
+                ChatEx.getInstance().getLogger().warning("Error while enabling AFK placeholder, neither essentials nor purpur were found!");
             }
         }
     }

--- a/src/main/java/de/jeter/chatex/utils/Config.java
+++ b/src/main/java/de/jeter/chatex/utils/Config.java
@@ -65,7 +65,7 @@ public enum Config {
     CHANGE_JOIN_AND_QUIT("Messages.JoinAndQuit.Enabled", false, "Do you want to change the join and the quit messages?"),
     RGB_COLORS("colors", null, "Requires 1.16+, Colors you want to use."),
     RGB_COLORS_EXAMPLE("colors.$g", "#00ff00", "Default color code. &g in chat will be used with the #00ff00."),
-    AFK_PLACEHOLDER("AfkPlaceholder.Enabled", false, "Enable the %afk placeholder. You can use it to display AFK players on tablist. (Requires Essentials)."),
+    AFK_PLACEHOLDER("AfkPlaceholder.Enabled", false, "Enable the %afk placeholder. You can use it to display AFK players on tablist. (Requires Essentials or Purpur)."),
     AFK_FORMAT("AfkPlaceholder.format", "&r[&7AFK&r] ", "The format of the afk placeholder.");
 
     private final Object value;

--- a/src/main/java/de/jeter/chatex/utils/HookManager.java
+++ b/src/main/java/de/jeter/chatex/utils/HookManager.java
@@ -38,4 +38,12 @@ public class HookManager {
         return plugin != null && plugin.isEnabled();
     }
 
+    public static boolean checkPurpur() {
+        try {
+            Class.forName("org.purpurmc.purpur.event.PlayerAFKEvent");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/de/jeter/chatex/utils/Utils.java
+++ b/src/main/java/de/jeter/chatex/utils/Utils.java
@@ -65,11 +65,7 @@ public class Utils {
             result = PlaceholderAPI.setPlaceholders(player, result);
         }
 
-        if (HookManager.checkEssentials() && Config.AFK_PLACEHOLDER.getBoolean()) {
-            result = result.replace("%afk", "");
-        }
-
-        if (HookManager.checkPurpur() && Config.AFK_PLACEHOLDER.getBoolean()) {
+        if ((HookManager.checkEssentials() || HookManager.checkPurpur()) && Config.AFK_PLACEHOLDER.getBoolean()) {
             result = result.replace("%afk", "");
         }
 

--- a/src/main/java/de/jeter/chatex/utils/Utils.java
+++ b/src/main/java/de/jeter/chatex/utils/Utils.java
@@ -69,6 +69,10 @@ public class Utils {
             result = result.replace("%afk", "");
         }
 
+        if (HookManager.checkPurpur() && Config.AFK_PLACEHOLDER.getBoolean()) {
+            result = result.replace("%afk", "");
+        }
+
         result = result.replace("%displayname", player.getDisplayName());
         result = result.replace("%prefix", PluginManager.getInstance().getPrefix(player));
         result = result.replace("%suffix", PluginManager.getInstance().getSuffix(player));


### PR DESCRIPTION
 To enable purpur afk, change `player-idle-time` in `server.properties` and  change `kick-if-idle` to `false` in `purpur.yml`.

Tested.

![2022-07-29_15 53 15](https://user-images.githubusercontent.com/45266046/181711779-4e6089cf-55ac-4cd7-9ba0-3e65978f2d40.png)
