### PR TITLE
feat(hex-colors): add ability to use color gradients

### DIFF
--- a/src/main/java/de/jeter/chatex/utils/RGBColors.java
+++ b/src/main/java/de/jeter/chatex/utils/RGBColors.java
@@ -2,10 +2,13 @@ package de.jeter.chatex.utils;
 
 import de.jeter.chatex.ChatEx;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class RGBColors {
 
@@ -88,4 +91,51 @@ public class RGBColors {
         }
         return !supported;
     }
+
+    public static String translateGradientCodes(String message) {
+        Pattern pattern = Pattern.compile("&g#([A-Fa-f0-9]{6})#([A-Fa-f0-9]{6})#([^&]+)&g");
+        Matcher matcher = pattern.matcher(message);
+        //for all matches
+        while (matcher.find()) {
+            String hexColor1 = "#" + matcher.group(1);
+            String hexColor2 = "#" + matcher.group(2);
+            String text = matcher.group(3);
+            message = message.replace(matcher.group(0), gradientText(text, hexColor1, hexColor2)+ ChatColor.RESET);
+        }
+        return message;
+    }
+
+    public static String gradientText(String text, String hexColor1, String hexColor2) {
+        StringBuilder result = new StringBuilder();
+        int length = text.length();
+        int[][] rgbValues = new int[2][3];
+        float[][] colorSteps = new float[2][3];
+        int[] currentRGB = new int[3];
+
+        rgbValues[0][0] = Integer.parseInt(hexColor1.substring(1, 3), 16);
+        rgbValues[0][1] = Integer.parseInt(hexColor1.substring(3, 5), 16);
+        rgbValues[0][2] = Integer.parseInt(hexColor1.substring(5, 7), 16);
+
+        rgbValues[1][0] = Integer.parseInt(hexColor2.substring(1, 3), 16);
+        rgbValues[1][1] = Integer.parseInt(hexColor2.substring(3, 5), 16);
+        rgbValues[1][2] = Integer.parseInt(hexColor2.substring(5, 7), 16);
+
+        for (int i = 0; i < 3; i++) {
+            colorSteps[0][i] = (float)(rgbValues[1][i] - rgbValues[0][i]) / length;
+            currentRGB[i] = rgbValues[0][i];
+        }
+
+        for (int i = 0; i < length; i++) {
+            String hexColor = String.format("#%02x%02x%02x", currentRGB[0], currentRGB[1], currentRGB[2]);
+            result.append("&" + hexColor + text.charAt(i));
+
+            // Update RGB values for next character
+            for (int j = 0; j < 3; j++) {
+                currentRGB[j] += colorSteps[0][j];
+            }
+        }
+
+        return result.toString();
+    }
+
 }

--- a/src/main/java/de/jeter/chatex/utils/Utils.java
+++ b/src/main/java/de/jeter/chatex/utils/Utils.java
@@ -35,6 +35,7 @@ public class Utils {
     }
 
     public static String replaceColors(String message) {
+        message = RGBColors.translateGradientCodes(message);
         message = RGBColors.translateCustomColorCodes(message);
         return ChatColor.translateAlternateColorCodes('&', message);
     }


### PR DESCRIPTION
Added Hex color gradients as a neat little feature.
Here is the pattern to make a gradient:
```&g[HexColor1][HexColor2]#[text]&g```

a small example would be:
```&g#ff0000#00ff00#HelloWorld!&g This message was a gradient!```

![image](https://user-images.githubusercontent.com/75166283/236688937-3225dd56-389e-4b14-ab96-611c9fcaf716.png)
